### PR TITLE
feat: drop staging environment, consolidate env vars, secure Mux uploads

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,4 +1,5 @@
 {
-  "workspaceId": "187b496f-c445-4942-94f2-74b74a99711a",
-  "defaultEnvironment": "dev"
+  "workspaceId": "b381f056-d4eb-49e4-afdd-757ceb91fbe4",
+  "defaultEnvironment": "dev",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,9 @@ import { env } from 'node:process';
 
 import { withPayload } from '@payloadcms/next/withPayload';
 
-const domain = env.VERCEL_TARGET_ENV === 'preview' ? env.VERCEL_URL : env.DOMAIN;
+// Mirror getServerSideUrl(): the stable per-branch host on preview so image remotePatterns
+// matches the absolute URLs Payload builds from serverURL.
+const domain = env.VERCEL_TARGET_ENV === 'preview' ? env.VERCEL_BRANCH_URL : env.NEXT_PUBLIC_DOMAIN;
 const isProductionNode = env.NODE_ENV === 'production';
 const isProductionVercel = env.VERCEL_TARGET_ENV === 'production';
 

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -20,6 +20,7 @@ import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f
 import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { MuxUploaderField as MuxUploaderField_c369a797e256de625eba826a6acb8608 } from '@oversightstudio/mux-video/elements'
 import { MuxVideoGifCell as MuxVideoGifCell_c369a797e256de625eba826a6acb8608 } from '@oversightstudio/mux-video/elements'
+import { MuxPlaybackPoller as MuxPlaybackPoller_96660e283b97c9852b15e5e2b2af83f2 } from '@/payload/components/mux-playback-poller.tsx'
 import { EnvBanner as EnvBanner_0b34fa9f1d1f920e244fee9510548f07 } from '@/payload/components/env-banner.tsx'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
@@ -48,6 +49,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@oversightstudio/mux-video/elements#MuxUploaderField": MuxUploaderField_c369a797e256de625eba826a6acb8608,
   "@oversightstudio/mux-video/elements#MuxVideoGifCell": MuxVideoGifCell_c369a797e256de625eba826a6acb8608,
+  "@/payload/components/mux-playback-poller.tsx#MuxPlaybackPoller": MuxPlaybackPoller_96660e283b97c9852b15e5e2b2af83f2,
   "@/payload/components/env-banner.tsx#EnvBanner": EnvBanner_0b34fa9f1d1f920e244fee9510548f07,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next';
 
 import { env } from '@/env/client';
+import { getServerSideUrl } from '@/payload/utils/get-server-side-url';
 
 export default function robots(): MetadataRoute.Robots {
   if (env.NEXT_PUBLIC_VERCEL_TARGET_ENV !== 'production') {
@@ -15,6 +16,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: ['/admin/', '/next/', '/api/'],
     },
-    sitemap: `${env.NEXT_PUBLIC_SERVER_URL}/sitemap.xml`,
+    sitemap: `${getServerSideUrl()}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,11 +4,12 @@ import { getPayload } from 'payload';
 
 import { env } from '@/env/client';
 import config from '@/payload/payload.config';
+import { getServerSideUrl } from '@/payload/utils/get-server-side-url';
 
 const getPagesSitemap = unstable_cache(
   async (): Promise<MetadataRoute.Sitemap> => {
     const payload = await getPayload({ config });
-    const siteUrl = env.NEXT_PUBLIC_SERVER_URL;
+    const siteUrl = getServerSideUrl();
 
     const results = await payload.find({
       collection: 'pages',

--- a/src/env/client.ts
+++ b/src/env/client.ts
@@ -6,16 +6,14 @@ export const env = createEnv({
     NEXT_PUBLIC_UMAMI_SRC: z.string().min(1),
     NEXT_PUBLIC_UMAMI_ID: z.string().min(1),
     NEXT_PUBLIC_DOMAIN: z.string().min(1),
-    NEXT_PUBLIC_SERVER_URL: z.string().min(1),
     NEXT_PUBLIC_VERCEL_TARGET_ENV: z
-      .enum(['development', 'preview', 'staging', 'production'])
+      .enum(['development', 'preview', 'production'])
       .default('development'),
   },
   runtimeEnv: {
     NEXT_PUBLIC_UMAMI_SRC: process.env.NEXT_PUBLIC_UMAMI_SRC,
     NEXT_PUBLIC_UMAMI_ID: process.env.NEXT_PUBLIC_UMAMI_ID,
     NEXT_PUBLIC_DOMAIN: process.env.NEXT_PUBLIC_DOMAIN,
-    NEXT_PUBLIC_SERVER_URL: process.env.NEXT_PUBLIC_SERVER_URL,
     NEXT_PUBLIC_VERCEL_TARGET_ENV: process.env.NEXT_PUBLIC_VERCEL_TARGET_ENV,
   },
 });

--- a/src/env/server.ts
+++ b/src/env/server.ts
@@ -3,10 +3,7 @@ import { z } from 'zod';
 
 export const env = createEnv({
   server: {
-    DOMAIN: z.string().min(1),
-    VERCEL_TARGET_ENV: z
-      .enum(['development', 'preview', 'staging', 'production'])
-      .default('development'),
+    VERCEL_TARGET_ENV: z.enum(['development', 'preview', 'production']).default('development'),
     MUX_TOKEN_ID: z.string().min(1),
     MUX_TOKEN_SECRET: z.string().min(1),
     MUX_WEBHOOK_SIGNING_SECRET: z.string().min(1),
@@ -21,19 +18,10 @@ export const env = createEnv({
     R2_SECRET_ACCESS_KEY: z.string().min(1),
     RESEND_API_KEY: z.string().min(1),
     RESEND_FROM_ADDRESS_DEFAULT: z.string().min(1),
-    RESEND_FROM_ADDRESS_PAYLOAD: z.string().min(1),
-    RESEND_FROM_NAME_DEFAULT: z.string().min(1),
     RESEND_TO_ADDRESS_DEFAULT: z.string().min(1),
-    SERVER_URL: z
-      .string()
-      .min(1)
-      .transform((url) =>
-        process.env.VERCEL_TARGET_ENV === 'preview' ? `https://${process.env.VERCEL_URL}` : url,
-      ),
     WHITELIST: z.string().min(1),
   },
   runtimeEnv: {
-    DOMAIN: process.env.DOMAIN,
     VERCEL_TARGET_ENV: process.env.VERCEL_TARGET_ENV,
     MUX_TOKEN_ID: process.env.MUX_TOKEN_ID,
     MUX_TOKEN_SECRET: process.env.MUX_TOKEN_SECRET,
@@ -49,10 +37,7 @@ export const env = createEnv({
     R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     RESEND_FROM_ADDRESS_DEFAULT: process.env.RESEND_FROM_ADDRESS_DEFAULT,
-    RESEND_FROM_ADDRESS_PAYLOAD: process.env.RESEND_FROM_ADDRESS_PAYLOAD,
-    RESEND_FROM_NAME_DEFAULT: process.env.RESEND_FROM_NAME_DEFAULT,
     RESEND_TO_ADDRESS_DEFAULT: process.env.RESEND_TO_ADDRESS_DEFAULT,
-    SERVER_URL: process.env.SERVER_URL,
     WHITELIST: process.env.WHITELIST,
   },
 });

--- a/src/payload/collections/form-submissions.ts
+++ b/src/payload/collections/form-submissions.ts
@@ -66,7 +66,7 @@ const sendFormSubmissionEmail: CollectionAfterOperationHook<'form-submissions'> 
 
       const resend = new Resend(env.RESEND_API_KEY);
       const { error } = await resend.emails.send({
-        from: `Wedding Day Content Co. <${env.RESEND_FROM_ADDRESS_PAYLOAD}>`,
+        from: `Wedding Day Content Co. <${env.RESEND_FROM_ADDRESS_DEFAULT}>`,
         to: env.RESEND_TO_ADDRESS_DEFAULT,
         subject: subject || `New ${form.title} Submission`,
         react: FormSubmissionEmailTemplate({ data: result.data, form }),

--- a/src/payload/collections/mux-video.ts
+++ b/src/payload/collections/mux-video.ts
@@ -1,0 +1,38 @@
+import type { CollectionConfig, Field } from 'payload';
+
+import { env } from '@/env/server';
+import { Role, hasRole } from '@/payload/access';
+
+// Preview/dev only: Mux's "asset ready" webhook can't reach rotating preview hosts (or localhost),
+// so a client-side poller fills `playbackOptions` from the Mux API via /api/mux/refresh. Production
+// relies on the webhook and omits both this field and that endpoint (see payload.config.ts). The
+// field is `type: 'ui'` — no DB column — so gating it by env keeps the schema identical everywhere.
+const playbackPollerField: Field = {
+  name: 'playbackPoller',
+  type: 'ui',
+  admin: {
+    components: {
+      Field: '@/payload/components/mux-playback-poller.tsx#MuxPlaybackPoller',
+    },
+  },
+};
+
+/**
+ * Base collection merged into `@oversightstudio/mux-video`'s generated collection via the plugin's
+ * `extendCollection` option (its fields are concatenated onto the plugin's).
+ *
+ * Access: public `read` so videos render on the public site, plus role-gated writes matching the
+ * rest of the CMS. The `read` here overrides the plugin's generated read, which mirrors the plugin
+ * `access` option — and that option doubles as the guard for the plugin's `/mux/upload` URL-minting
+ * endpoints, so it is locked to Admin/Editor in payload.config.ts rather than left public.
+ */
+export const MuxVideo: CollectionConfig<'mux-video'> = {
+  slug: 'mux-video',
+  access: {
+    read: () => true,
+    create: hasRole(Role.Admin, Role.Editor),
+    update: hasRole(Role.Admin, Role.Editor),
+    delete: hasRole(Role.Admin),
+  },
+  fields: env.VERCEL_TARGET_ENV === 'production' ? [] : [playbackPollerField],
+};

--- a/src/payload/components/env-banner.tsx
+++ b/src/payload/components/env-banner.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react';
 
-type Environment = 'local' | 'preview' | 'staging' | 'production';
+type Environment = 'local' | 'preview' | 'production';
 
 const ENV_STYLES: Record<Environment, CSSProperties> = {
   local: {
@@ -12,11 +12,6 @@ const ENV_STYLES: Record<Environment, CSSProperties> = {
     backgroundColor: 'var(--theme-success-100)',
     color: 'var(--theme-success-800)',
     borderColor: 'var(--theme-success-250)',
-  },
-  staging: {
-    backgroundColor: 'var(--theme-warning-100)',
-    color: 'var(--theme-warning-800)',
-    borderColor: 'var(--theme-warning-250)',
   },
   production: {
     backgroundColor: 'var(--theme-error-100)',
@@ -44,8 +39,6 @@ function getEnvironment(): Environment {
   switch (vercelEnv) {
     case 'preview':
       return 'preview';
-    case 'staging':
-      return 'staging';
     case 'production':
       return 'production';
   }

--- a/src/payload/components/mux-playback-poller.tsx
+++ b/src/payload/components/mux-playback-poller.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useDocumentInfo, useFormFields } from '@payloadcms/ui';
+import { useRouter } from 'next/navigation';
+
+const POLL_INTERVAL_MS = 5_000;
+const MAX_ATTEMPTS = 60; // ~5 minutes, then stop so a stuck encode can't poll forever
+const TERMINAL_STATUSES = ['errored', 'no-asset'];
+
+// Tracks docs already refreshed this session so that if a refresh doesn't immediately
+// surface the new playback data (stale form state), we don't fire refresh() again.
+const refreshedIds = new Set<string>();
+
+/**
+ * Mux's "asset ready" webhook cannot reach rotating preview hostnames, so on those deployments a
+ * freshly uploaded video is saved with an `assetId` but no `playbackOptions` and never finishes.
+ * This component pulls status from Mux instead: while an asset exists without playback data it
+ * polls `/api/mux/refresh` until the asset is ready, then refreshes the view. It is a harmless
+ * no-op once playback data is present (production keeps relying on the webhook).
+ */
+export function MuxPlaybackPoller() {
+  const { id } = useDocumentInfo();
+  const router = useRouter();
+
+  const assetId = useFormFields(([fields]) => fields?.assetId?.value);
+  const playbackRows = useFormFields(
+    ([fields]) => (fields?.playbackOptions as { rows?: unknown[] } | undefined)?.rows?.length ?? 0,
+  );
+
+  useEffect(() => {
+    if (!id || !assetId || playbackRows > 0) {
+      return;
+    }
+
+    let active = true;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const poll = async () => {
+      attempts += 1;
+
+      try {
+        const response = await fetch('/api/mux/refresh', {
+          method: 'post',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id }),
+        });
+
+        if (!active) {
+          return;
+        }
+
+        // A 4xx won't recover on retry (e.g. an expired admin session returns 401); stop.
+        // 5xx is treated as transient and falls through to the bounded retry below.
+        if (!response.ok && response.status < 500) {
+          return;
+        }
+
+        const result = (await response.json()) as { ready?: boolean; status?: string };
+
+        if (result.ready) {
+          const key = String(id);
+
+          if (!refreshedIds.has(key)) {
+            refreshedIds.add(key);
+            router.refresh();
+          }
+
+          return;
+        }
+
+        if (TERMINAL_STATUSES.includes(result.status ?? '') || attempts >= MAX_ATTEMPTS) {
+          return;
+        }
+      } catch {
+        if (!active || attempts >= MAX_ATTEMPTS) {
+          return;
+        }
+      }
+
+      timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+
+    void poll();
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, [id, assetId, playbackRows, router]);
+
+  if (!assetId || playbackRows > 0) {
+    return null;
+  }
+
+  return <div style={{ fontSize: '0.8rem', opacity: 0.8 }}>Checking Mux for encoding status</div>;
+}

--- a/src/payload/payload.config.ts
+++ b/src/payload/payload.config.ts
@@ -24,26 +24,125 @@ import {
   lexicalEditor,
 } from '@payloadcms/richtext-lexical';
 import { s3Storage } from '@payloadcms/storage-s3';
-import { buildConfig } from 'payload';
+import { type Endpoint, buildConfig } from 'payload';
 import sharp from 'sharp';
 
 import { env } from '@/env/server';
-import { Role } from '@/payload/access';
+import { Role, hasRole } from '@/payload/access';
 import { Clients } from '@/payload/collections/clients';
 import { Faqs } from '@/payload/collections/faqs';
 import { FormSubmissions } from '@/payload/collections/form-submissions';
 import { Forms } from '@/payload/collections/forms';
 import { Images } from '@/payload/collections/images';
+import { MuxVideo } from '@/payload/collections/mux-video';
 import { Pages } from '@/payload/collections/pages';
 import { Users } from '@/payload/collections/users';
 import { richTextFields } from '@/payload/fields/link';
 import { Footer } from '@/payload/globals/footer';
 import { Navigation } from '@/payload/globals/navigation';
+import { getServerSideUrl } from '@/payload/utils/get-server-side-url';
+
+type MuxAsset = {
+  status: string;
+  aspect_ratio?: string;
+  duration?: number;
+  playback_ids?: { id: string; policy: 'public' | 'signed' }[];
+  tracks?: { type: string; max_width?: number; max_height?: number }[];
+};
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
 
-const whitelist = [env.SERVER_URL, ...env.WHITELIST.split(' ')].filter(Boolean);
+const serverUrl = getServerSideUrl();
+const whitelist = [serverUrl, ...env.WHITELIST.split(' ')].filter(Boolean);
+
+/**
+ * Preview/dev fallback for Mux's "asset ready" webhook, which cannot reach rotating preview hosts
+ * (or localhost). The MuxPlaybackPoller field calls this to pull asset status from the Mux API and
+ * fill `playbackOptions`. Registered only outside production (see endpoints below); production uses
+ * the webhook.
+ */
+const muxRefreshEndpoint: Endpoint = {
+  path: '/mux/refresh',
+  method: 'post',
+  handler: async (req) => {
+    if (!req.user || req.user.collection !== req.payload.config.admin.user) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // The update() below runs via the Local API with overrideAccess, bypassing the collection's
+    // update access control — so gate the endpoint to the same write roles.
+    if (!hasRole(Role.Admin, Role.Editor)({ req })) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = (await req.json?.()) as { id?: string } | undefined;
+    const id = body?.id;
+
+    if (!id) {
+      return Response.json({ error: 'Missing id' }, { status: 400 });
+    }
+
+    const doc = await req.payload.findByID({ collection: 'mux-video', id }).catch(() => null);
+
+    if (!doc) {
+      // Doc was deleted, or the id is malformed — nothing to refresh; terminal for the poller.
+      return Response.json({ ready: false, status: 'no-asset' });
+    }
+
+    if (doc.playbackOptions?.length) {
+      return Response.json({ ready: true });
+    }
+
+    if (!doc.assetId) {
+      return Response.json({ ready: false, status: 'no-asset' });
+    }
+
+    const auth = Buffer.from(`${env.MUX_TOKEN_ID}:${env.MUX_TOKEN_SECRET}`).toString('base64');
+    const response = await fetch(`https://api.mux.com/video/v1/assets/${doc.assetId}`, {
+      headers: { Authorization: `Basic ${auth}` },
+    });
+
+    if (!response.ok) {
+      // A 4xx from Mux (e.g. the asset was deleted on Mux's side) won't recover on retry — return a
+      // terminal status so the poller stops. A 5xx is transient: surface it as 502 and let the
+      // poller retry (bounded by MAX_ATTEMPTS).
+      if (response.status < 500) {
+        return Response.json({ ready: false, status: 'no-asset' });
+      }
+
+      return Response.json({ ready: false, status: 'error' }, { status: 502 });
+    }
+
+    const { data: asset } = (await response.json()) as { data: MuxAsset };
+
+    if (asset.status !== 'ready') {
+      return Response.json({ ready: false, status: asset.status });
+    }
+
+    const videoTrack = asset.tracks?.find((track) => track.type === 'video');
+
+    await req.payload.update({
+      collection: 'mux-video',
+      id,
+      data: {
+        // Re-send the unchanged assetId: the plugin's beforeChange hook deletes the Mux asset when
+        // the incoming assetId differs from the stored one, so omitting it (undefined !== stored)
+        // would destroy the asset.
+        assetId: doc.assetId,
+        playbackOptions: asset.playback_ids?.map((playback) => ({
+          playbackId: playback.id,
+          playbackPolicy: playback.policy,
+        })),
+        aspectRatio: asset.aspect_ratio?.replace(':', '/'),
+        duration: asset.duration,
+        ...(videoTrack ? { maxWidth: videoTrack.max_width, maxHeight: videoTrack.max_height } : {}),
+      },
+    });
+
+    return Response.json({ ready: true });
+  },
+};
 
 export default buildConfig({
   admin: {
@@ -84,6 +183,7 @@ export default buildConfig({
     Pages,
     Faqs,
     Images,
+    MuxVideo,
     // crm
     Clients,
     Forms,
@@ -134,6 +234,8 @@ export default buildConfig({
         }
       },
     },
+    // Preview/dev only: production fills playback data via the Mux webhook and never polls.
+    ...(env.VERCEL_TARGET_ENV === 'production' ? [] : [muxRefreshEndpoint]),
   ],
   db: postgresAdapter({
     pool: {
@@ -163,7 +265,7 @@ export default buildConfig({
   }),
   email: resendAdapter({
     defaultFromAddress: env.RESEND_FROM_ADDRESS_DEFAULT,
-    defaultFromName: env.RESEND_FROM_NAME_DEFAULT,
+    defaultFromName: 'Wedding Day Content Co.',
     apiKey: env.RESEND_API_KEY,
   }),
   globals: [Navigation, Footer],
@@ -190,15 +292,21 @@ export default buildConfig({
   plugins: [
     muxVideoPlugin({
       enabled: true,
+      extendCollection: 'mux-video',
       initSettings: {
         tokenId: env.MUX_TOKEN_ID || '',
         tokenSecret: env.MUX_TOKEN_SECRET || '',
         webhookSecret: env.MUX_WEBHOOK_SIGNING_SECRET || '',
       },
       uploadSettings: {
-        cors_origin: env.SERVER_URL,
+        // Pin CORS to the canonical origin in production; preview hosts rotate and local dev has no
+        // stable origin, so both use a wildcard (uploads are still gated behind admin auth).
+        cors_origin: env.VERCEL_TARGET_ENV === 'production' ? serverUrl : '*',
       },
-      access: () => true,
+      // Guards the plugin's /mux/upload endpoints, which mint Mux direct-upload URLs — Mux warns
+      // these must be authenticated or anyone could ingest assets into the account. Public read is
+      // handled by the collection's own read access (see collections/mux-video.ts).
+      access: (req) => hasRole(Role.Admin, Role.Editor)({ req }) === true,
     }),
     nestedDocsPlugin({
       collections: ['pages'],
@@ -225,7 +333,7 @@ export default buildConfig({
     }),
   ],
   secret: env.PAYLOAD_SECRET,
-  serverURL: env.SERVER_URL,
+  serverURL: serverUrl,
   sharp,
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/src/payload/utils/get-client-side-url.test.ts
+++ b/src/payload/utils/get-client-side-url.test.ts
@@ -7,7 +7,7 @@ import { getClientSideUrl } from '@/payload/utils/get-client-side-url';
 
 describe('getClientSideUrl (no DOM)', () => {
   beforeEach(() => {
-    vi.stubEnv('NEXT_PUBLIC_SERVER_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_DOMAIN', '');
     vi.stubEnv('NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL', '');
   });
 
@@ -20,8 +20,8 @@ describe('getClientSideUrl (no DOM)', () => {
     expect(getClientSideUrl()).toBe('https://example.vercel.app');
   });
 
-  it('falls back to NEXT_PUBLIC_SERVER_URL', () => {
-    vi.stubEnv('NEXT_PUBLIC_SERVER_URL', 'https://site.test');
+  it('falls back to the custom domain', () => {
+    vi.stubEnv('NEXT_PUBLIC_DOMAIN', 'site.test');
     expect(getClientSideUrl()).toBe('https://site.test');
   });
 

--- a/src/payload/utils/get-client-side-url.ts
+++ b/src/payload/utils/get-client-side-url.ts
@@ -13,5 +13,5 @@ export const getClientSideUrl = () => {
     return `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`;
   }
 
-  return process.env.NEXT_PUBLIC_SERVER_URL || '';
+  return process.env.NEXT_PUBLIC_DOMAIN ? `https://${process.env.NEXT_PUBLIC_DOMAIN}` : '';
 };

--- a/src/payload/utils/get-server-side-url.test.ts
+++ b/src/payload/utils/get-server-side-url.test.ts
@@ -4,7 +4,9 @@ import { getServerSideUrl } from '@/payload/utils/get-server-side-url';
 
 describe('getServerSideUrl', () => {
   beforeEach(() => {
-    vi.stubEnv('NEXT_PUBLIC_SERVER_URL', '');
+    vi.stubEnv('VERCEL_TARGET_ENV', '');
+    vi.stubEnv('VERCEL_BRANCH_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_DOMAIN', '');
     vi.stubEnv('NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL', '');
   });
 
@@ -12,13 +14,21 @@ describe('getServerSideUrl', () => {
     vi.unstubAllEnvs();
   });
 
-  it('returns NEXT_PUBLIC_SERVER_URL when set (takes precedence over Vercel)', () => {
-    vi.stubEnv('NEXT_PUBLIC_SERVER_URL', 'https://site.test');
+  it('uses the per-branch Vercel url on preview deployments', () => {
+    vi.stubEnv('VERCEL_TARGET_ENV', 'preview');
+    vi.stubEnv('VERCEL_BRANCH_URL', 'app-git-my-branch.vercel.app');
+    vi.stubEnv('NEXT_PUBLIC_DOMAIN', 'site.test');
+    expect(getServerSideUrl()).toBe('https://app-git-my-branch.vercel.app');
+  });
+
+  it('uses the custom domain on production (over the Vercel production url)', () => {
+    vi.stubEnv('VERCEL_TARGET_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_DOMAIN', 'site.test');
     vi.stubEnv('NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL', 'fallback.vercel.app');
     expect(getServerSideUrl()).toBe('https://site.test');
   });
 
-  it('prefixes the Vercel production url with https when SERVER_URL is absent', () => {
+  it('falls back to the Vercel production url when no custom domain is set', () => {
     vi.stubEnv('NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL', 'example.vercel.app');
     expect(getServerSideUrl()).toBe('https://example.vercel.app');
   });

--- a/src/payload/utils/get-server-side-url.ts
+++ b/src/payload/utils/get-server-side-url.ts
@@ -1,13 +1,18 @@
 export const getServerSideUrl = () => {
-  let url = process.env.NEXT_PUBLIC_SERVER_URL;
+  // Preview deployments: the stable per-branch host (constant across re-deploys, unlike VERCEL_URL).
+  if (process.env.VERCEL_TARGET_ENV === 'preview' && process.env.VERCEL_BRANCH_URL) {
+    return `https://${process.env.VERCEL_BRANCH_URL}`;
+  }
 
-  if (!url && process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL) {
+  // Production: the canonical custom domain.
+  if (process.env.VERCEL_TARGET_ENV === 'production' && process.env.NEXT_PUBLIC_DOMAIN) {
+    return `https://${process.env.NEXT_PUBLIC_DOMAIN}`;
+  }
+
+  // Fallback to Vercel's generated production url when no custom domain is configured.
+  if (process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL) {
     return `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`;
   }
 
-  if (!url) {
-    url = 'http://localhost:3000';
-  }
-
-  return url;
+  return 'http://localhost:3000';
 };

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -21,7 +21,7 @@ export async function sendFallbackFormEmail(
     `Note: Database was unavailable. Please save this information manually.`,
   ].join('\n');
   const { error } = await resend.emails.send({
-    from: `Wedding Day Content Co. <${env.RESEND_FROM_ADDRESS_PAYLOAD}>`,
+    from: `Wedding Day Content Co. <${env.RESEND_FROM_ADDRESS_DEFAULT}>`,
     to: env.RESEND_TO_ADDRESS_DEFAULT,
     subject: `Form Submission - Database Unavailable - ${formId}`,
     text: textContent,


### PR DESCRIPTION
## Summary

Migrates off the dedicated Vercel **staging** environment to per-PR **preview URLs**, consolidates env vars, and hardens the Mux integration. Validated end-to-end on a preview deploy (browser→R2 uploads, Mux preview playback polling, upload-auth lockdown, new env structure).

### Drop staging + env consolidation
- Remove the now-unused env vars: `NEXT_PUBLIC_SERVER_URL`, `DOMAIN`, `SERVER_URL`, `RESEND_FROM_ADDRESS_PAYLOAD`, `RESEND_FROM_NAME_DEFAULT`.
- Remove the `staging` value from the `VERCEL_TARGET_ENV` / `NEXT_PUBLIC_VERCEL_TARGET_ENV` enums and the env banner.
- Centralize URL derivation in `get-server-side-url` / `get-client-side-url`; preview uses the stable `VERCEL_BRANCH_URL`, production the custom domain.
- Point `.infisical.json` at the new workspace.

### Mux preview playback polling
Mux's asset-ready webhook can't reach rotating preview hosts, so previews get a poll-based fallback:
- A `MuxPlaybackPoller` UI field on the `mux-video` collection (merged via the plugin's `extendCollection`) calls a new `POST /mux/refresh` endpoint that pulls asset status from the Mux API and fills `playbackOptions`.
- Both the field and the endpoint are **gated out of production** (webhook-only there). The field is `type: ui` → no DB column → schema is identical across environments.

### Security hardening
- The plugin `access` option guards both collection read **and** the `/mux/upload` URL-minting endpoints. It was `() => true` (anyone could mint upload URLs). Now locked to **Admin/Editor**, with public `read` set explicitly on the collection.
- Direct-upload CORS pinned to the canonical origin in production; wildcard only for preview/dev.

## Deploy steps (Infisical)
- [ ] `NEXT_PUBLIC_DOMAIN` set in **every** environment (bare host, no scheme).
- [ ] Removed `NEXT_PUBLIC_SERVER_URL`, `DOMAIN`, `SERVER_URL`, `RESEND_FROM_ADDRESS_PAYLOAD`, `RESEND_FROM_NAME_DEFAULT`.

## Verification
typecheck / lint / oxfmt clean, 162/162 unit tests pass. Reviewed via multi-agent (security, correctness, architecture, env-gating, push-readiness) with adversarial verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)