### PR TITLE
feat: mobile carousels for media stack and testimonials

### DIFF
--- a/src/components/blocks/media-stack.tsx
+++ b/src/components/blocks/media-stack.tsx
@@ -1,3 +1,10 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
 import { PayloadMedia } from '@/components/ui/payload-media';
 import type { PayloadMediaStackBlock } from '@/payload/payload-types';
 import type { StripString } from '@/types/strip-string';
@@ -5,24 +12,6 @@ import { cn } from '@/utils/cn';
 import { isRelationshipPopulated } from '@/utils/is-relationship-populated';
 
 type FilteredMedia = StripString<PayloadMediaStackBlock['media'][number]>;
-
-const scatterByCount: Record<number, string[]> = {
-  2: [
-    cn('lg:translate-x-4 lg:translate-y-1 lg:-rotate-3'),
-    cn('lg:-translate-x-8 lg:-translate-y-2 lg:rotate-3'),
-  ],
-  3: [
-    cn('lg:translate-x-4 lg:translate-y-1 lg:-rotate-3'),
-    cn('lg:-translate-x-4 lg:translate-y-1 lg:rotate-3'),
-    cn('lg:-translate-y-3 lg:rotate-2'),
-  ],
-  4: [
-    cn('lg:translate-x-4 lg:translate-y-2 lg:-rotate-3'),
-    cn('lg:-translate-x-4 lg:translate-y-2 lg:rotate-3'),
-    cn('lg:translate-x-4 lg:-translate-y-2 lg:rotate-3'),
-    cn('lg:-translate-x-4 lg:-translate-y-2 lg:-rotate-3'),
-  ],
-};
 
 export function MediaStackBlock({ media }: PayloadMediaStackBlock) {
   const filteredMedia = media?.filter((item) => isRelationshipPopulated<FilteredMedia>(item));
@@ -34,18 +23,37 @@ export function MediaStackBlock({ media }: PayloadMediaStackBlock) {
   const count = filteredMedia.length;
 
   return (
-    <div className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-1! lg:grid-cols-2!">
-      {filteredMedia.map(({ relationTo, value }, index) => (
-        <PayloadMedia
-          key={value.id}
-          relationTo={relationTo}
-          value={value}
-          className={cn('rounded-sm surface-card', 'first:z-10', scatterByCount[count]?.[index], {
-            'col-span-2 w-full justify-self-center xs:w-[calc(50%-0.5rem)] md:w-full lg:w-[calc(50%-0.5rem)]':
-              count === 3 && index === 2,
-          })}
-        />
-      ))}
-    </div>
+    <>
+      <Carousel className="md:hidden" aria-label="Image stack">
+        <CarouselContent className="items-center py-4">
+          {filteredMedia.map(({ relationTo, value }) => (
+            <CarouselItem key={value.id} className="basis-4/5">
+              <PayloadMedia
+                relationTo={relationTo}
+                value={value}
+                className="w-full rounded-sm surface-card"
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <div className="flex justify-between">
+          <CarouselPrevious />
+          <CarouselNext />
+        </div>
+      </Carousel>
+      <div className="hidden gap-4 md:grid md:grid-cols-1 lg:grid-cols-2">
+        {filteredMedia.map(({ relationTo, value }, index) => (
+          <PayloadMedia
+            key={value.id}
+            relationTo={relationTo}
+            value={value}
+            className={cn('w-full rounded-sm surface-card', {
+              'lg:col-span-2 lg:w-[calc(50%-0.5rem)] lg:justify-self-center':
+                count === 3 && index === 2,
+            })}
+          />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/components/blocks/quote-card.tsx
+++ b/src/components/blocks/quote-card.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import { Dialog } from '@/components/ui/dialog';
+import { Icons } from '@/icons';
+import { cn } from '@/utils/cn';
+
+interface QuoteCardProps {
+  client: string;
+  children: ReactNode;
+}
+
+export function QuoteCard({ client, children }: QuoteCardProps) {
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useEffect(() => {
+    const el = bodyRef.current;
+
+    if (!el) {
+      return;
+    }
+
+    const check = () => setOverflowing(el.scrollHeight > el.clientHeight + 1);
+
+    check();
+
+    const resizeObserver = new ResizeObserver(check);
+
+    resizeObserver.observe(el);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return (
+    <Dialog.Root>
+      <blockquote
+        className={cn(
+          'flex h-80 w-full flex-col gap-4 overflow-hidden',
+          'p-4',
+          'rounded-sm bg-neutral-100/75 surface-card dark:bg-neutral-900',
+        )}
+      >
+        <Icons
+          name="quoteSolid"
+          aria-hidden
+          className="size-12 shrink-0 self-center drop-shadow-lg dark:text-neutral-300"
+        />
+        <div ref={bodyRef} className="relative grow overflow-hidden text-lg">
+          {children}
+          {overflowing && (
+            <Dialog.Trigger
+              className={cn(
+                'absolute inset-x-0 bottom-0 flex items-end justify-center',
+                'pt-12 pb-1',
+                'text-sm font-medium text-neutral-600 dark:text-neutral-400',
+                'bg-linear-to-t from-neutral-100 from-30% to-transparent dark:from-neutral-900',
+                'cursor-pointer focus-ring-input',
+              )}
+            >
+              Read more
+            </Dialog.Trigger>
+          )}
+        </div>
+        <div className="shrink-0 text-xl font-medium drop-shadow-lg dark:text-neutral-300">
+          {client}
+        </div>
+      </blockquote>
+      {overflowing && (
+        <Dialog.Content>
+          <div className="flex flex-col gap-4">
+            <Icons name="quoteSolid" aria-hidden className="size-12 self-center drop-shadow-lg" />
+            <div className="text-lg">{children}</div>
+            <Dialog.Title>{client}</Dialog.Title>
+          </div>
+        </Dialog.Content>
+      )}
+    </Dialog.Root>
+  );
+}

--- a/src/components/blocks/quotes.tsx
+++ b/src/components/blocks/quotes.tsx
@@ -1,5 +1,13 @@
+import { QuoteCard } from '@/components/blocks/quote-card';
 import type { RichTextComponent } from '@/components/rich-text/types';
 import { Blockquote, BlockquoteBody, BlockquoteFooter } from '@/components/ui/blockquote';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
 import type { PayloadQuotesBlock } from '@/payload/payload-types';
 
 interface QuotesBlockProps extends PayloadQuotesBlock {
@@ -12,15 +20,32 @@ export function QuotesBlock({ quotes, RichText }: QuotesBlockProps) {
   }
 
   return (
-    <div className="masonry">
-      {quotes.map(({ client, content, id }) => (
-        <Blockquote key={id} className="masonry-item">
-          <BlockquoteBody>
-            <RichText data={content} />
-          </BlockquoteBody>
-          <BlockquoteFooter>{client}</BlockquoteFooter>
-        </Blockquote>
-      ))}
-    </div>
+    <>
+      <Carousel className="md:hidden" aria-label="Testimonials">
+        <CarouselContent className="py-4">
+          {quotes.map(({ client, content, id }) => (
+            <CarouselItem key={id} className="basis-4/5">
+              <QuoteCard client={client}>
+                <RichText data={content} />
+              </QuoteCard>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <div className="flex justify-between">
+          <CarouselPrevious />
+          <CarouselNext />
+        </div>
+      </Carousel>
+      <div className="hidden masonry md:block">
+        {quotes.map(({ client, content, id }) => (
+          <Blockquote key={id} className="masonry-item">
+            <BlockquoteBody>
+              <RichText data={content} />
+            </BlockquoteBody>
+            <BlockquoteFooter>{client}</BlockquoteFooter>
+          </Blockquote>
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { Dialog as BaseDialog } from '@base-ui/react/dialog';
+
+import { Icons } from '@/icons';
+import { cn } from '@/utils/cn';
+
+const Title = ({ className, ...props }: ComponentProps<typeof BaseDialog.Title>) => (
+  <BaseDialog.Title
+    className={cn('font-sans text-xl font-medium drop-shadow-lg', className)}
+    {...props}
+  />
+);
+
+const Description = ({ className, ...props }: ComponentProps<typeof BaseDialog.Description>) => (
+  <BaseDialog.Description className={cn('text-sm text-neutral-600', className)} {...props} />
+);
+
+const Content = ({ className, children, ...props }: ComponentProps<typeof BaseDialog.Popup>) => (
+  <BaseDialog.Portal>
+    <BaseDialog.Backdrop
+      className={cn(
+        'fixed inset-0 z-50 bg-neutral-50/25 backdrop-blur-md',
+        'transition-opacity duration-300 ease-out',
+        'data-ending-style:opacity-0 data-starting-style:opacity-0',
+      )}
+    />
+    <BaseDialog.Viewport className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <BaseDialog.Popup
+        className={cn(
+          'relative flex max-h-[85dvh] w-full max-w-lg flex-col',
+          'rounded-xs bg-neutral-50/75 text-neutral-800 shadow-lg ring-2 shadow-neutral-500/10 ring-neutral-200/75 outline-hidden backdrop-blur-lg',
+          'transition duration-300 ease-out',
+          'data-starting-style:scale-95 data-starting-style:opacity-0',
+          'data-ending-style:scale-95 data-ending-style:opacity-0',
+          className,
+        )}
+        {...props}
+      >
+        <BaseDialog.Close
+          aria-label="Close"
+          className={cn(
+            'absolute top-3 right-3 z-10',
+            'inline-flex size-8 items-center justify-center',
+            'rounded-xs text-neutral-500',
+            'transition-colors hover:bg-neutral-200 hover:text-black',
+            'cursor-pointer focus-ring-input',
+          )}
+        >
+          <Icons name="x" className="size-4" />
+        </BaseDialog.Close>
+        <div className="overflow-y-auto p-6">{children}</div>
+      </BaseDialog.Popup>
+    </BaseDialog.Viewport>
+  </BaseDialog.Portal>
+);
+
+export const Dialog = {
+  Root: BaseDialog.Root,
+  Trigger: BaseDialog.Trigger,
+  Close: BaseDialog.Close,
+  Content,
+  Title,
+  Description,
+};


### PR DESCRIPTION
## Summary

Mobile-responsive rework of the two content blocks that didn't degrade well on phones, plus a new Dialog primitive.

### Media stack ([media-stack.tsx](src/components/blocks/media-stack.tsx))
- **Fix:** the first image shrank "to oblivion" at small sizes once the block allowed four images. Root cause: images had no `w-full`, so as grid items (replaced elements default to `justify-self: start`) they rendered at intrinsic size. Now they fill their cell.
- **Layout:** carousel below `md`; vertical stack at `md`; two-column grid at `lg` (three-image case centers the third). Dropped the `lg` scatter/rotate styling.

### Testimonials ([quotes.tsx](src/components/blocks/quotes.tsx), [quote-card.tsx](src/components/blocks/quote-card.tsx))
- Below `md`, quotes become a carousel of **fixed-height** cards so they're uniform.
- When a quote overflows its card, a **"Read more"** fade-out trigger opens the full quote in a dialog (overflow detected client-side via `ResizeObserver`).
- The `md+` masonry layout is unchanged.

### New Dialog primitive ([dialog.tsx](src/components/ui/dialog.tsx))
- Built on Base UI (`@base-ui/react/dialog`), exported as a namespace (`Dialog.Root`, `Dialog.Content`, `Dialog.Title`, …).
- Styled to match the navigation overlay (frosted-glass surface, light-only) with a baked-in close button.

## Verification
- `pnpm typecheck`, `pnpm lint`, `oxfmt` all clean.
- `pnpm test`: 162 node tests pass (browser-mode test files need a local `playwright install`; unrelated to this change).
- Not visually verified in a running app — worth eyeballing: 4-image stack on a phone, a long quote → dialog open/close/Esc, a short quote showing no "Read more".

🤖 Generated with [Claude Code](https://claude.com/claude-code)